### PR TITLE
Fix Keylime registrar and verifier initialization and add tenant script

### DIFF
--- a/start-keylime-registrar.sh
+++ b/start-keylime-registrar.sh
@@ -1,1 +1,6 @@
-podman run --rm -d -v ~/keylime/CERTS:/var/lib/keylime:z -p 8890:8890 -p 8891:8891 --network=host  localhost/keylime_registrar
+podman run --rm -d \
+    -v ~/keylime/CERTS:/var/lib/keylime:z \
+    -p 8890:8890 -p 8891:8891 \
+    -e KEYLIME_REGISTRAR_IP=0.0.0.0 \
+    --name registrar \
+    localhost/keylime_registrar

--- a/start-keylime-verifier.sh
+++ b/start-keylime-verifier.sh
@@ -1,2 +1,8 @@
 mkdir -p ~/keylime/CERTS
-podman run --rm -d -v ~/keylime/CERTS:/var/lib/keylime:z -p 8880:8880 -p 8881:8881 --network=host localhost/keylime_verifier
+podman run --rm -di \
+    -v ~/keylime/CERTS:/var/lib/keylime:z \
+    -p 8880:8880 \
+    -p 8881:8881 \
+    --name verifier \
+    -e KEYLIME_VERIFIER_IP=0.0.0.0 \
+    localhost/keylime_verifier

--- a/tenant.sh
+++ b/tenant.sh
@@ -1,0 +1,43 @@
+# Run the keylime tenant in a container, passing the provided arguments
+#
+# The registrar and verifier IP can be set via the --registrar and --verifier
+# respectively
+#
+# If not provided, it is assumed the registrar and the verifier are running in
+# the local machine and set the IP using the local IP
+
+TENANT_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --registrar)
+      REGISTRAR_IP="$2"
+      shift 2
+      ;;
+    --verifier)
+      VERIFIER_IP="$2"
+      shift 2
+      ;;
+    *)
+      # Capture the other arguments and pass to the tenant
+      TENANT_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${REGISTRAR_IP}" ]]; then
+    REGISTRAR_IP=$(hostname -I | awk '{print $1}')
+fi
+
+if [[ -z "${VERIFIER_IP}" ]]; then
+    VERIFIER_IP=$(hostname -I | awk '{print $1}')
+fi
+
+# Run the tenant in the container passing the collected arguments
+podman run --rm -ti \
+    -e KEYLIME_TENANT_REGISTRAR_IP=${REGISTRAR_IP} \
+    -e KEYLIME_TENANT_VERIFIER_IP=${VERIFIER_IP} \
+    --network host \
+    -v ~/keylime/CERTS:/var/lib/keylime:z \
+    localhost/keylime_tenant ${TENANT_ARGS[@]}


### PR DESCRIPTION
This fixes the registrar and verifier IP setup, so that they accept any incoming requests.

This also adds the `tenant.sh` script, which wraps the use of the tenant running inside a container.

The registrar and verifier to be accessed can be set in the `tenant.sh` script via the `--registrar` and `--verifier` options, respectively. If no IP is provided, it is assumed the registrar and verifier are running in the local machine and the IP set is the local IP.